### PR TITLE
[#5] setting layout

### DIFF
--- a/app/components/layout/Layout.tsx
+++ b/app/components/layout/Layout.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import useWindowSize from "hooks/useWindowSize";
+import { PropsWithChildren, useEffect } from "react";
+import styled from "styled-components";
+
+let vh = 0;
+
+function Layout({ children }: PropsWithChildren) {
+  const windowSize = useWindowSize();
+
+  useEffect(() => {
+    vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty("--vh", `${vh}px`);
+  }, [windowSize.height]);
+
+  return <StyledWrapper>{children}</StyledWrapper>;
+}
+
+export default Layout;
+
+const StyledWrapper = styled.div`
+  width: 100%;
+  height: 100vh;
+  min-height: calc(var(--var, 1vh) * 100);
+  max-width: 480px;
+  margin: 0 auto;
+`;

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,5 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}

--- a/app/hooks/useWindowSize.ts
+++ b/app/hooks/useWindowSize.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+
+interface Size {
+  width: number | undefined;
+  height: number | undefined;
+}
+
+function useWindowSize(): Size {
+  const [windowSize, setWindowSize] = useState<Size>({
+    width: undefined,
+    height: undefined,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    };
+
+    window.addEventListener("resize", handleResize);
+    handleResize();
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowSize;
+}
+
+export default useWindowSize;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,7 @@
-import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+"use client";
 
-const inter = Inter({ subsets: ["latin"] });
-
-export const metadata: Metadata = {
-  title: "Christmas Test",
-  description: "☃️ 크리스마스에 뭐하지?",
-};
+import Layout from "components/layout/Layout";
+import "globals.css";
 
 export default function RootLayout({
   children,
@@ -15,7 +10,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body>{children}</body>
+      <body>
+        <Layout>{children}</Layout>
+      </body>
     </html>
   );
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "app",
     "target": "es5",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
## 🎅🏻 작업 내용

- [x] 레이아웃 

## ⛄️ 리뷰 포인트

**Layout component**를 만들어서 layout page에 적용했어요
width는 480px이고 
useWindowSize 훅은 resize 이벤트 리스너를 부착해서 브라우저의 현재 사이즈를 알아내는 훅이에요
환경에 따라서 보여지는 게 달라서 (카카오로 사이트 들어가면 url 바가 스크롤에 따라 사라졌다가 다시 나옴 등) 해당 훅이 필요했어요
[참고 사이트](https://dev.to/kunalukey/how-to-create-your-own-usewindowsize-hook-in-reactjs-4g02?utm_source=oneoneone)에서 자세히 볼 수 있어요

<img src="https://github.com/ChristmasTest/christmas/assets/63100352/1efd08e5-8530-49e3-959c-31145a8a6c5b" width="55%" />

(핑크색은 예시일뿐 코드에는 안넣었어용)

## ❄️ 기타 사항

GlobalStyle 적용하시는 분이 현재 globals.css에 있는 거 사용해주시면 됩니다
적용하시면 globals.css는 지워주세용

```tsx
* {
  margin: 0;
  padding: 0;
  box-sizing: border-box;
}
```
